### PR TITLE
Include basic testing template

### DIFF
--- a/priv/templates/clojerl_app.template
+++ b/priv/templates/clojerl_app.template
@@ -3,9 +3,11 @@
     {name, "mylib", "Name of the Clojerl application"},
     {desc, "A Clojerl application", "Short description of the app"}
 ]}.
+{template, "core.clje.tpl", "{{name}}/src/{{name}}/core.clje"}.
 {template, "app.clje.tpl", "{{name}}/src/{{name}}/app.clje"}.
 {template, "sup.clje.tpl", "{{name}}/src/{{name}}/sup.clje"}.
 {template, "app.src.tpl", "{{name}}/src/{{name}}.app.src"}.
+{template, "core_test.clje.tpl", "{{name}}/test/{{name}}/core_test.clje"}.
 {template, "rebar.config.tpl", "{{name}}/rebar.config"}.
 {template, "gitignore.tpl", "{{name}}/.gitignore"}.
 {template, "LICENSE.tpl", "{{name}}/LICENSE"}.

--- a/priv/templates/core.clje.tpl
+++ b/priv/templates/core.clje.tpl
@@ -1,0 +1,1 @@
+(ns {{name}}.core)

--- a/priv/templates/core_test.clje.tpl
+++ b/priv/templates/core_test.clje.tpl
@@ -1,0 +1,7 @@
+(ns {{name}}.core-test
+  (:require [clojure.test :refer :all]
+            [{{name}}.core :refer :all]))
+
+(deftest a-test
+  (testing "FIXME, I fail."
+    (is (= 0 1))))


### PR DESCRIPTION
This mirrors a basic lein project test file.

I also took the liberty to add a `core.clje` file in order to match the test. This example is also created by lein and mix generates a similar module by default.

Let me know what you think.