### PR TITLE
Tweaked release plugin to mirror Erlang more closely.

### DIFF
--- a/priv/templates/clojerl_release.template
+++ b/priv/templates/clojerl_release.template
@@ -9,11 +9,11 @@
 {template, "release.rebar.config.tpl", "{{name}}/rebar.config"}.
 {template, "gitignore.tpl", "{{name}}/.gitignore"}.
 
-{template, "core.clje.tpl", "{{name}}/src/{{name}}/core.clje"}.
-{template, "app.clje.tpl", "{{name}}/src/{{name}}/app.clje"}.
-{template, "sup.clje.tpl", "{{name}}/src/{{name}}/sup.clje"}.
-{template, "app.src.tpl", "{{name}}/src/{{name}}.app.src"}.
-{template, "core_test.clje.tpl", "{{name}}/test/{{name}}/core_test.clje"}.
+{template, "core.clje.tpl", "{{name}}/apps/{{name}}/src/{{name}}/core.clje"}.
+{template, "app.clje.tpl", "{{name}}/apps/{{name}}/src/{{name}}/app.clje"}.
+{template, "sup.clje.tpl", "{{name}}/apps/{{name}}/src/{{name}}/sup.clje"}.
+{template, "app.src.tpl", "{{name}}/apps/{{name}}/src/{{name}}.app.src"}.
+{template, "core_test.clje.tpl", "{{name}}/apps/{{name}}/test/{{name}}/core_test.clje"}.
 
 {template, "sys.config.tpl", "{{name}}/config/sys.config"}.
 {template, "vm.args.tpl", "{{name}}/config/vm.args"}.

--- a/priv/templates/release.rebar.config.tpl
+++ b/priv/templates/release.rebar.config.tpl
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 
 {deps, [{clojerl, "0.6.0"}]}.
-{plugins, [{rebar3_clojerl, "0.8.0"}]}.
+{plugins, [{rebar3_clojerl, "0.8.1"}]}.
 
 {relx, [ { release
          , {{{name}}, "0.1.0"}


### PR DESCRIPTION
Per my comments in #79, I've offered a change here (and guessed at a micro version bump) that brings this plugin into closer alignment with the results of `rebar3 new release ...`

