### PR TITLE
[#83] Update .app files with modules before creating a release

### DIFF
--- a/src/rebar3_clojerl_prv_release.erl
+++ b/src/rebar3_clojerl_prv_release.erl
@@ -32,8 +32,24 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
+  update_all_app_files(State),
+  %% Generate release
   rebar_relx:do(rlx_prv_release, "release", ?PROVIDER, State).
 
 -spec format_error(any()) -> iolist().
 format_error(Reason) ->
   io_lib:format("~p", [Reason]).
+
+%% =============================================================================
+%% Internal functions
+%% =============================================================================
+
+-spec update_all_app_files(rebar_state:t()) -> ok.
+update_all_app_files(State) ->
+  %% Update .app file for all apps
+  DepsPaths   = rebar_state:code_paths(State, all_deps),
+  ProjectApps = rebar_state:project_apps(State),
+  AppsPaths   = [rebar_app_info:ebin_dir(AppInfo) || AppInfo <- ProjectApps],
+  AllPaths    = DepsPaths ++ AppsPaths,
+  [rebar3_clojerl_utils:update_app_file(Dir)|| Dir <- AllPaths],
+  ok.


### PR DESCRIPTION
### Problem

The compilation process of a Clojerl application sometime results in more than one `.beam` file for a specific module. This is because of the way protocols are implemented and compiled.

The `compile` commands addresses the duplicated `.beam` files problem by removing duplicates after all applications are Clojerl-compiled. To avoid other tools (e.g. `relx`) getting confused by this situation the `compile` command used to update the `.app` file for the applications where a duplicated `.beam` file had been detected. But not all applications had their `.app` file updated, so that it would list all modules for which a `.beam` file still existed in each application.

When creating a release through `rebar3 release` (or the more recent `rebar3 clojerl release`) and trying to start the application in `embedded` mode, the generated [`boot` script](https://erlang.org/doc/man/script.html) by `relx` did not include Clojerl modules (and missed other Clojerl protocol modules as well). These missing modules were not loaded when the VM started, resulting in errors like the one shown in #48 

Starting the VM in `interactive` mode by setting the environment variable `CODE_LOADING_MODE=interactive` allowed the release to start successfully, but was more a workaround than a solution.

###  Solution

This PR introduces code that updates all the `.app` files in the project before creating a release with `rebar3 clojerl release`. This ensures that all necessary modules will be included in the boot script, which in turn means that the release will successfully start in `embedded` mode.

#83 