### PR TITLE
Support for relx 4.0 as per rebar 3.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Compile clojerl projects
 
 ## Use
 
+In order to use this plugin you should have `rebar3` greater than
+`v3.14.0` installed.
+
 Add the plugin to your `rebar.config` (along with `clojerl` as a
 dependency):
 

--- a/src/rebar3_clojerl_prv_release.erl
+++ b/src/rebar3_clojerl_prv_release.erl
@@ -33,7 +33,7 @@ init(State) ->
 do(State) ->
   update_all_app_files(State),
   %% Generate release
-  rebar_relx:do(rlx_prv_release, "release", ?PROVIDER, State).
+  rebar_relx:do(?PROVIDER, State).
 
 -spec format_error(any()) -> iolist().
 format_error(Reason) ->


### PR DESCRIPTION
For more information please refer to https://github.com/erlang/rebar3/pull/2257

With this change `rebar3 clojerl release` works as expected with the latest rebar3 versions. Please let me know if we need to specify the rebar3 version people are expected to use in the README.