### PR TITLE
[#14] Add `--config` flag for the REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,12 @@ by running for example:
     $ rebar3 help clojerl repl
     Start a clojerl repl
 	Usage: rebar3 clojerl repl [--apps <apps>] [--sname <sname>]
+	                           [--config <config>]
 
 	  --apps   List of applications that should be started separated by commas
 	           (e.g. --apps app1,app2,app3).
 	  --sname  Erlang node name.
+	  --config  Path to the config file to load.
 
 ### rebar.config options
 

--- a/src/rebar3_clojerl_prv_repl.erl
+++ b/src/rebar3_clojerl_prv_repl.erl
@@ -6,6 +6,9 @@
 -define(NAMESPACE, clojerl).
 -define(DEPS, [{?NAMESPACE, compile}]).
 
+%% Redefining configuration for these apps can lead to errors.
+-define(APP_BLACKLIST, [inets, stdlib, kernel, rebar]).
+
 -type opts() :: [{atom(), any()}].
 
 %% =============================================================================
@@ -21,6 +24,9 @@ init(State) ->
              , { sname, undefined, "sname", string
                , "Erlang node name."
                }
+             , { config, undefined, "config", string
+               , "Path to the config file to load."
+               }
              ],
   Provider = providers:create([ {namespace,  ?NAMESPACE}
                               , {name,       ?PROVIDER}
@@ -29,7 +35,7 @@ init(State) ->
                               , {deps,       ?DEPS}
                               , { example
                                 , "rebar3 clojerl repl "
-                                  "--sname foo --apps bar,baz"
+                                  "--sname foo --apps bar,baz --config sys.config"
                                 }
                               , {opts,       Opts}
                               , {short_desc, "Start a clojerl repl"}
@@ -54,14 +60,17 @@ format_error(Reason) ->
 -spec repl(rebar_state:t()) -> ok.
 repl(State) ->
   maybe_restart_clojerl(),
-  Bindings  = #{<<"#'clojure.core/*compile-files*">> => false},
+  Bindings    = #{<<"#'clojure.core/*compile-files*">> => false},
+  DepsPaths   = rebar_state:code_paths(State, all_deps),
+  {Opts, _}   = rebar_state:command_parsed_args(State),
+  AppsToStart = read_apps(proplists:get_value(apps, Opts, "")),
 
-  DepsPaths = rebar_state:code_paths(State, all_deps),
   code:add_pathsa(DepsPaths),
 
-  {Opts, _} = rebar_state:command_parsed_args(State),
-  ok        = maybe_start_apps(Opts),
-  ok        = rebar3_clojerl_utils:maybe_set_sname(Opts),
+  ok          = load_apps(AppsToStart),
+  ok          = maybe_apply_config(AppsToStart, State, Opts),
+  ok          = rebar3_clojerl_utils:maybe_set_sname(Opts),
+  ok          = maybe_start_apps(Opts),
 
   try
     ok = 'clojerl.Var':push_bindings(Bindings),
@@ -89,7 +98,51 @@ maybe_start_apps(Opts) ->
   case proplists:get_value(apps, Opts, undefined) of
     undefined -> ok;
     AppsStr ->
-      Apps = [list_to_atom(X) || X <- string:tokens(AppsStr, ",")],
+      Apps = read_apps(AppsStr),
       [application:ensure_all_started(Name) || Name <- Apps],
+      ok
+  end.
+
+-spec load_apps([atom()]) -> ok.
+load_apps(Apps) ->
+  [ case application:load(App) of
+      ok ->
+        {ok, Ks} = application:get_all_key(App),
+        %% Load dependencies as well
+        load_apps(proplists:get_value(applications, Ks));
+      _ -> error
+    end
+    || App <- Apps
+  ],
+  ok.
+
+-spec read_config(rebar_state:t(), opts()) -> [[tuple()]] | no_config.
+read_config(State, Opts) ->
+  case proplists:get_value(config, Opts, no_value) of
+    no_value -> no_config;
+    Filename when is_list(Filename) ->
+      rebar_file_utils:consult_config(State, Filename)
+  end.
+
+-spec read_apps(string()) -> [atom()].
+read_apps(AppsStr) ->
+  [list_to_atom(X) || X <- string:tokens(AppsStr, ",")].
+
+-spec maybe_apply_config([atom()], rebar_state:t(), opts()) -> ok.
+maybe_apply_config(AppsToStart, State, Opts) ->
+  case read_config(State, Opts) of
+    no_config -> ok;
+    ConfigList ->
+      %% Copied from:
+      %% https://github.com/erlang/rebar3/blob/master/src/rebar_prv_shell.erl
+      Running = [App || {App, _, _} <- application:which_applications()],
+      [ application:stop(App)
+	|| Config   <- ConfigList,
+	   {App, _} <- Config,
+	   lists:member(App, Running),
+	   lists:member(App, AppsToStart),
+	   not lists:member(App, ?APP_BLACKLIST)
+      ],
+      _ = rebar_utils:reread_config(ConfigList, [update_logger]),
       ok
   end.


### PR DESCRIPTION
Initial support for loading an Erlang configuration file to use while on a REPL session, similar (but very basic) to the way `rebar3 shell` does.

Closes #14 